### PR TITLE
Fix for error "GLFW error 65539: Invalid Key" 

### DIFF
--- a/src/main/java/net/mehvahdjukaar/cagerium/common/CageItem.java
+++ b/src/main/java/net/mehvahdjukaar/cagerium/common/CageItem.java
@@ -5,6 +5,7 @@ import com.mojang.blaze3d.platform.InputConstants;
 import net.mehvahdjukaar.cagerium.CageriumClient;
 import net.mehvahdjukaar.cagerium.client.CageItemRenderer;
 import net.minecraft.ChatFormatting;
+import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.model.geom.EntityModelSet;
@@ -22,6 +23,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraftforge.client.IItemRenderProperties;
 import net.minecraftforge.common.util.NonNullLazy;
 import org.jetbrains.annotations.Nullable;
+import org.lwjgl.glfw.GLFW;
 
 import java.util.List;
 import java.util.function.BiFunction;
@@ -37,7 +39,7 @@ public class CageItem extends BlockItem {
     @Override
     public void appendHoverText(ItemStack pStack, @Nullable Level pLevel, List<Component> pTooltip, TooltipFlag pFlag) {
         var c = pStack.getTagElement("BlockEntityTag");
-        if( InputConstants.isKeyDown(Minecraft.getInstance().getWindow().getWindow(),  Minecraft.getInstance().options.keyShift.getKey().getValue())){
+        if( isKeyDown(Minecraft.getInstance().options.keyShift)){
             pTooltip.add(new TextComponent("aaaa"));
         }
 
@@ -65,6 +67,20 @@ public class CageItem extends BlockItem {
         CageriumClient.registerISTER(consumer, CageItemRenderer::new);
     }
 
-
-
+    private static boolean isKeyDown(KeyMapping keyBinding) {
+        InputConstants.Key key = keyBinding.getKey();
+        int keyCode = key.getValue();
+        if (keyCode != InputConstants.UNKNOWN.getValue()) {
+            long windowHandle = Minecraft.getInstance().getWindow().getWindow();
+            try {
+                if (key.getType() == InputConstants.Type.KEYSYM) {
+                    return InputConstants.isKeyDown(windowHandle, keyCode);
+                } else if (key.getType() == InputConstants.Type.MOUSE) {
+                    return GLFW.glfwGetMouseButton(windowHandle, keyCode) == GLFW.GLFW_PRESS;
+                }
+            } catch (Exception ignored) {
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
Error which occurs from binding mouse keys to the sneak control.
As reported on the vault hunters discord ([Error](https://discord.com/channels/889424759018901514/889845714207801344/1085022326032179251))

Identical to the issue observed with [MiningGadgets](https://github.com/Direwolf20-MC/MiningGadgets/commit/05ac678d0a9bac6a56fc36d8904625e29080965c). - Hardcoded in MiningGadget.java to check if shift is held down.
And fixed with the more elegant approach of [Mekanism](https://github.com/mekanism/Mekanism/commit/8de59c0e32b53d7029d3c2c333bbc7e8fb79d4f3). - Softcoded in a seperate key handler to accept any key that can be used for sneak.



